### PR TITLE
Added support for Cordova 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "semver": "^6.0.0",
     "xcode": "^0.8.3"
   },
   "bundledDependencies": [

--- a/src/disable-bitcode.js
+++ b/src/disable-bitcode.js
@@ -7,6 +7,7 @@
 var fs = require('fs');
 var xcode = require('xcode');
 var path = require('path');
+var semver = require('semver');
 
 module.exports = function(context) {
   var projectName, projectPath, xcodeProj;
@@ -24,8 +25,6 @@ module.exports = function(context) {
 };
 
 function getConfigParser(context, config){
-  var semver = context.requireCordovaModule('semver');
-
   if(semver.lt(context.opts.cordova.version, '5.4.0')) {
     ConfigParser = context.requireCordovaModule('cordova-lib/src/ConfigParser/ConfigParser');
   } else {


### PR DESCRIPTION
As of Cordova 9.0.0 `requireCordovaModule` has been deprecated for non-cordova modules resulting in the following error when installing the plugin:

> ERROR: Using "requireCordovaModule" to load non-cordova module "semver" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.

I added `semver` as a dependency and imported it with `require` to resolve the issue.